### PR TITLE
Linguist Fix!

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 system/vendor/* linguist-vendored
+themes/* linguist-vendored
 README.md linguist-documentation

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+system/vendor/* linguist-vendored
+README.md linguist-documentation


### PR DESCRIPTION
Linguist set the project as 50% JS and some CSS/Smarty so I fixed it so the theme/vendor paths are ignored by linguist. Now it's back to being classified as PHP.